### PR TITLE
Update CloudflareApiController.cs

### DIFF
--- a/UmbracoFlare/ApiControllers/CloudflareApiController.cs
+++ b/UmbracoFlare/ApiControllers/CloudflareApiController.cs
@@ -35,6 +35,8 @@ namespace UmbracoFlare.ApiControllers
         public CloudflareApiController()
             : base()
         {
+            // CloudFlare only works with TLS 1.2 now
+            System.Net.ServicePointManager.SecurityProtocol = System.Net.SecurityProtocolType.Tls12;
             //Get the ApiKey and AccountEmail from the web.config settings.
             _apiKey = CloudflareConfiguration.Instance.ApiKey;
             _accountEmail = CloudflareConfiguration.Instance.AccountEmail;


### PR DESCRIPTION
Update CloudflareApiController to force TLS 1.2 now that CloudFlare requires it